### PR TITLE
upgrade fury to 0.9.0 and enable native build

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -70,7 +70,6 @@
         </plugins>
     </build>
 
-    <!-- Disable native build currently
     <profiles>
         <profile>
             <id>native-image</id>
@@ -95,5 +94,4 @@
             </properties>
         </profile>
     </profiles>
-    -->
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <quarkus.version>3.16.2</quarkus.version>
-        <fury.version>0.8.0</fury.version>
+        <fury.version>0.9.0</fury.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Closes #7 

Native build works:

![image](https://github.com/user-attachments/assets/1a4715ff-979a-4aa0-a8bd-6f15339465bf)
![image](https://github.com/user-attachments/assets/66e080c9-020b-4eb4-a0ee-114c367c4635)

