### PR TITLE
Support to use application-fury in resteasy

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -16,6 +16,10 @@
             <artifactId>quarkus-arc-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-common-spi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.fury</groupId>
             <artifactId>quarkus-fury</artifactId>
             <version>${project.version}</version>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest</artifactId>
+            <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.fury</groupId>

--- a/integration-tests/src/main/java/io/quarkiverse/fury/it/FuryResources.java
+++ b/integration-tests/src/main/java/io/quarkiverse/fury/it/FuryResources.java
@@ -5,8 +5,10 @@ import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 
 import org.apache.fury.BaseFury;
 import org.apache.fury.Fury;
@@ -73,5 +75,16 @@ public class FuryResources {
         Struct struct2 = (Struct) fury.deserialize(fury.serialize(struct1));
 
         return struct1.equals(struct2);
+    }
+
+    @GET
+    @Path("/test")
+    @Produces("application/fury")
+    @Consumes("application/fury")
+    public Bar testBar(Bar obj) {
+        Preconditions.checkArgument(obj.f1() == 1, obj);
+        Preconditions.checkArgument(obj.f2().equals("hello bar"), obj);
+
+        return new Bar(2, "bye bar");
     }
 }

--- a/integration-tests/src/test/java/io/quarkiverse/fury/it/FuryTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/fury/it/FuryTest.java
@@ -3,9 +3,14 @@ package io.quarkiverse.fury.it;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
+import org.apache.fury.Fury;
+import org.apache.fury.config.FuryBuilder;
+import org.apache.fury.config.Language;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
 
 @QuarkusTest
 public class FuryTest {
@@ -23,5 +28,21 @@ public class FuryTest {
     @Test
     public void testThirdPartyBar() {
         given().when().get("/fury/third_party_bar").then().statusCode(200).body(is("true"));
+    }
+
+    @Test
+    public void testFuryBar() {
+        Bar bar = new Bar(1, "hello bar");
+        Fury fury = new FuryBuilder().withLanguage(Language.JAVA).requireClassRegistration(true).build();
+        fury.register(Bar.class);
+        fury.registerSerializer(Bar.class, BarSerializer.class);
+
+        Response response = given().contentType("application/fury").body(fury.serialize(bar)).when()
+                .get("/fury/test").then().statusCode(200).contentType("application/fury").extract().response();
+
+        byte[] result = response.body().asByteArray();
+        Bar bar2 = (Bar) fury.deserialize(result);
+        Assertions.assertEquals(bar2.f1(), 2);
+        Assertions.assertEquals(bar2.f2(), "bye bar");
     }
 }

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -16,11 +16,19 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.fury</groupId>
             <artifactId>fury-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/runtime/src/main/java/io/quarkiverse/fury/ClassicFurySerializer.java
+++ b/runtime/src/main/java/io/quarkiverse/fury/ClassicFurySerializer.java
@@ -1,0 +1,80 @@
+package io.quarkiverse.fury;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
+
+import org.apache.fury.BaseFury;
+import org.apache.fury.Fury;
+import org.apache.fury.ThreadSafeFury;
+import org.apache.fury.io.FuryInputStream;
+import org.apache.fury.resolver.ClassResolver;
+
+import io.quarkus.arc.Arc;
+
+@Provider
+@Consumes({ "application/fury", "application/*+fury" })
+@Produces({ "application/fury", "application/*+fury" })
+public class ClassicFurySerializer implements MessageBodyReader<Object>, MessageBodyWriter<Object> {
+    private BaseFury fury;
+
+    public ClassicFurySerializer() {
+    }
+
+    @Override
+    public boolean isReadable(final Class<?> aClass, final Type type, final Annotation[] annotations,
+            final MediaType mediaType) {
+        return isSupportedMediaType(mediaType) && canSerialize(aClass);
+    }
+
+    @Override
+    public Object readFrom(final Class<Object> aClass, final Type type, final Annotation[] annotations,
+            final MediaType mediaType, final MultivaluedMap<String, String> multivaluedMap, final InputStream inputStream)
+            throws WebApplicationException {
+        return getFury().deserialize(new FuryInputStream(inputStream));
+    }
+
+    @Override
+    public boolean isWriteable(final Class<?> aClass, final Type type, final Annotation[] annotations,
+            final MediaType mediaType) {
+        return isSupportedMediaType(mediaType) && canSerialize(aClass);
+    }
+
+    @Override
+    public void writeTo(final Object obj, final Class<?> aClass, final Type type, final Annotation[] annotations,
+            final MediaType mediaType, final MultivaluedMap<String, Object> multivaluedMap, final OutputStream outputStream)
+            throws IOException, WebApplicationException {
+        outputStream.write(getFury().serialize(obj));
+    }
+
+    private boolean isSupportedMediaType(MediaType mediaType) {
+        return mediaType.getType().equals("application") && mediaType.getSubtype().endsWith("fury");
+    }
+
+    private boolean canSerialize(final Class<?> aClass) {
+        if (getFury() instanceof final ThreadSafeFury threadSafeFury) {
+            return (threadSafeFury).execute(f -> f.getClassResolver().getRegisteredClassId(aClass)) != null;
+        } else {
+            ClassResolver classResolver = ((Fury) getFury()).getClassResolver();
+            return classResolver.getRegisteredClassId(aClass) != null;
+        }
+    }
+
+    private BaseFury getFury() {
+        if (fury == null) {
+            fury = Arc.container().instance(BaseFury.class).get();
+        }
+        return fury;
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/fury/ClassicFurySerializerProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/fury/ClassicFurySerializerProducer.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.fury;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+
+@Dependent
+public class ClassicFurySerializerProducer {
+    @Produces
+    @ApplicationScoped
+    public ClassicFurySerializer create() {
+        return new ClassicFurySerializer();
+    }
+}


### PR DESCRIPTION
This will support to use `application/fury` as a mediatype and de(serialize) objects over the HTTP connections.

see `testFuryBar()` method.