### PR TITLE
Produce ModuleOpenBuildItem for add-opens=java.base/java.lang.invoke as per Fory JDK 25+ requirements

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/fory/deployment/ForyProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/fory/deployment/ForyProcessor.java
@@ -32,10 +32,12 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.ModuleOpenBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyReaderBuildItem;
 import io.quarkus.resteasy.reactive.spi.MessageBodyWriterBuildItem;
+import io.quarkus.runtime.util.JavaVersionGreaterOrEqual25;
 
 class ForyProcessor {
 
@@ -45,6 +47,11 @@ class ForyProcessor {
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep(onlyIf = JavaVersionGreaterOrEqual25.class)
+    ModuleOpenBuildItem openJavaLangInvoke() {
+        return new ModuleOpenBuildItem("java.base", "org.apache.fory.core", "java.lang.invoke");
     }
 
     @BuildStep


### PR DESCRIPTION
From the notes in the Fory installation guide:


>On JDK25+, open java.lang.invoke to Fory. Use ALL-UNNAMED when Fory is on the classpath:
>
> `--add-opens=java.base/java.lang.invoke=ALL-UNNAMED`

