### PR TITLE
ci: build across multiple JDKs (17, 21, 25)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,13 @@ defaults:
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
+    name: Build on ${{ matrix.os }} with JDK ${{ matrix.java }}
     strategy:
       fail-fast: false
       matrix:
 #        os: [windows-latest, macos-latest, ubuntu-latest]
         os: [ubuntu-latest]
+        java: [17, 21, 25]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Prepare git
@@ -49,11 +50,11 @@ jobs:
         if: startsWith(matrix.os, 'windows')
 
       - uses: actions/checkout@v7
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: ${{ matrix.java }}
           cache: 'maven'
 
       - name: Build with Maven


### PR DESCRIPTION
## Summary

Extends the CI build matrix to compile and test against multiple JDK versions instead of only JDK 17.

- **JDK 17** — Quarkus 3.37 baseline (current single target)
- **JDK 21** — current LTS
- **JDK 25** — directly relevant since #179 added the `--add-opens=java.base/java.lang.invoke` requirement for Fory on JDK 25+, so this ensures regressions on newer JDKs are caught in CI

## Changes

- `.github/workflows/build.yml`: add a `java` matrix dimension (`[17, 21, 25]`) and wire the `setup-java` step to `matrix.java`.

The native build step (`-Dnative -Dquarkus.native.container-build`) is unaffected — it uses a container-based native toolchain, so it doesn't depend on a locally-installed GraalVM matching `matrix.java`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
